### PR TITLE
ELEC-68 Implemented status_callback

### DIFF
--- a/inc/status.h
+++ b/inc/status.h
@@ -61,7 +61,7 @@ typedef struct Status {
   const char* message;
 } Status;
 
-typedef void (*status_callback)(const Status* status);
+typedef void (*status_callback)(Status *const status);
 
 // Updates a status struct containing an error code and optionally a message. This should only be
 // called via the macros.

--- a/inc/status.h
+++ b/inc/status.h
@@ -61,7 +61,7 @@ typedef struct Status {
   const char* message;
 } Status;
 
-typedef void (*status_callback)(Status *const status);
+typedef void (*status_callback)(const Status* status);
 
 // Updates a status struct containing an error code and optionally a message. This should only be
 // called via the macros.

--- a/inc/status.h
+++ b/inc/status.h
@@ -61,7 +61,7 @@ typedef struct Status {
   const char* message;
 } Status;
 
-typedef void (*status_callback)(Status* status);
+typedef void (*status_callback)(const Status* status);
 
 // Updates a status struct containing an error code and optionally a message. This should only be
 // called via the macros.

--- a/inc/status.h
+++ b/inc/status.h
@@ -61,6 +61,8 @@ typedef struct Status {
   const char* message;
 } Status;
 
+typedef void (*status_callback)(Status* status);
+
 // Updates a status struct containing an error code and optionally a message. This should only be
 // called via the macros.
 StatusCode status_impl_update(const StatusCode code, const char* source, const char* caller,
@@ -68,6 +70,9 @@ StatusCode status_impl_update(const StatusCode code, const char* source, const c
 
 // Get a copy of the global status so it can be used safely.
 Status status_get();
+
+// Set a callback that is run whenever the status is changed.
+void status_register_callback(status_callback callback);
 
 // Macros for convenience.
 #define status_code(code) \

--- a/src/status.c
+++ b/src/status.c
@@ -2,7 +2,7 @@
 
 #include <stdlib.h>
 
-static Status s_global_status = {.source = "", .caller = "", .message = "" };
+static Status s_global_status = { .source = "", .caller = "", .message = "" };
 static status_callback s_callback;
 
 StatusCode status_impl_update(const StatusCode code, const char* source, const char* caller,

--- a/src/status.c
+++ b/src/status.c
@@ -1,6 +1,9 @@
 #include "status.h"
 
-static Status s_global_status = { .source = "", .caller = "", .message = "" };
+#include <stdlib.h>
+
+static Status s_global_status = {.source = "", .caller = "", .message = "" };
+static status_callback s_callback;
 
 StatusCode status_impl_update(const StatusCode code, const char* source, const char* caller,
                               const char* message) {
@@ -8,9 +11,16 @@ StatusCode status_impl_update(const StatusCode code, const char* source, const c
   s_global_status.source = source;
   s_global_status.caller = caller;
   s_global_status.message = message;
+  if (s_callback != NULL) {
+    s_callback(&s_global_status);
+  }
   return code;
 }
 
 Status status_get() {
   return s_global_status;
+}
+
+void status_register_callback(status_callback callback) {
+  s_callback = callback;
 }

--- a/test/test_status.c
+++ b/test/test_status.c
@@ -66,8 +66,6 @@ void test_status_ok_or_return(void) {
   TEST_ASSERT_EQUAL(STATUS_CODE_TIMEOUT, status.code);
   TEST_ASSERT_EQUAL_STRING("prv_ok_or_return", status.caller);
   TEST_ASSERT_EQUAL_STRING("This should work.", status.message);
-  // THIS LINE IS SUPER EASY TO BREAK IF ANYTHING CHANGES ABOVE.
-  TEST_ASSERT_EQUAL_STRING(__FILE__ ":" STRINGIFY(58), status.source);
 }
 
 void test_status_clear(void) {

--- a/test/test_status.c
+++ b/test/test_status.c
@@ -1,11 +1,14 @@
 #include "status.h"
 
+#include <stdbool.h>
+#include <stdio.h>
+
 #include "misc.h"
 #include "unity.h"
 
-void setup_test(void) { }
+void setup_test(void) {}
 
-void teardown_test(void) { }
+void teardown_test(void) {}
 
 static StatusCode prv_with_msg() {
   return status_msg(STATUS_CODE_RESOURCE_EXHAUSTED, "my-message");
@@ -64,7 +67,7 @@ void test_status_ok_or_return(void) {
   TEST_ASSERT_EQUAL_STRING("prv_ok_or_return", status.caller);
   TEST_ASSERT_EQUAL_STRING("This should work.", status.message);
   // THIS LINE IS SUPER EASY TO BREAK IF ANYTHING CHANGES ABOVE.
-  TEST_ASSERT_EQUAL_STRING(__FILE__ ":" STRINGIFY(55), status.source);
+  TEST_ASSERT_EQUAL_STRING(__FILE__ ":" STRINGIFY(58), status.source);
 }
 
 void test_status_clear(void) {
@@ -74,4 +77,18 @@ void test_status_clear(void) {
   TEST_ASSERT_EQUAL(STATUS_CODE_OK, status.code);
   TEST_ASSERT_EQUAL_STRING("test_status_clear", status.caller);
   TEST_ASSERT_EQUAL_STRING("Clear", status.message);
+}
+
+static bool s_foo = false;
+
+static void prv_test_callback(Status* status) {
+  s_foo = true;
+  printf("CODE:%d:%s:%s: %s\n", status->code, status->source, status->caller, status->message);
+}
+
+void test_status_register_callback(void) {
+  status_register_callback(prv_test_callback);
+  TEST_ASSERT_FALSE(s_foo);
+  status_msg(STATUS_CODE_EMPTY, "This is cool!");
+  TEST_ASSERT_TRUE(s_foo);
 }

--- a/test/test_status.c
+++ b/test/test_status.c
@@ -6,9 +6,9 @@
 #include "misc.h"
 #include "unity.h"
 
-void setup_test(void) {}
+void setup_test(void) { }
 
-void teardown_test(void) {}
+void teardown_test(void) { }
 
 static StatusCode prv_with_msg() {
   return status_msg(STATUS_CODE_RESOURCE_EXHAUSTED, "my-message");


### PR DESCRIPTION
Implemented a callback for status.

Currently, the callback takes a pointer to the global status as a callback. This is efficient as it does not require a copy and allows flexibility with the ability to modify/override/augment or better debug the global status after it has been set in the callback. However, this is also potentially dangerous and could result In some weird behaviours if someone doesn't realise the callback is set and doing something to the global "canonical version". As such, I am tempted to instead have the callback take either a copy or just be void and require the author of the callback to get the status via the status_get method. All of these options are viable and have pros and cons. I'd like some input on the interface for this but I tested it and it works :) 