### PR TITLE
ELEC-86: Deprecate ms-common repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# lib
+# ms-common (Deprecated)
 
-Midnight Sun's HAL/FSM library. Name subject to change.
+**Warning**: This is an outdated copy of Midnight Sun's HAL. Use the [firmware](https://github.com/uw-midsun/firmware) repo for new development.
 
+This repo is kept purely so we can reference old PRs and commits.


### PR DESCRIPTION
Moving ms-common directly into firmware repo. This repo is kept only to keep track of previous PRs.